### PR TITLE
Update the vendor

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/apache/openwhisk-intellij-plugin">
     <id>org.apache.openwhisk.intellij</id>
     <name>Apache OpenWhisk</name>
-    <vendor email="dev@openwhisk.apache.org" url="https://openwhisk.apache.org/">Apache OpenWhisk</vendor>
+    <vendor email="gmcdonald@apache.org" url="https://apache.org/">apache</vendor>
     <version>1.0.0</version>
     <idea-version since-build="191.*" until-build="211.*"/>
 


### PR DESCRIPTION
This is required to transfer the plugin to the apache software foundation.
<img width="920" alt="스크린샷 2021-06-08 오후 4 57 35" src="https://user-images.githubusercontent.com/3447251/121146212-ae411c00-c87a-11eb-86e9-65d05b1ce284.png">
